### PR TITLE
add react-router

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.14",
     "truffle-contract": "^3.0.0"
   },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,63 +1,17 @@
 import React, { Component } from 'react';
-import EventContract from './contracts/Event.json'
-import getWeb3 from './utils/getWeb3'
+import { BrowserRouter, Route } from 'react-router-dom'
+import NewEvent from './NewEvent'
+import Event from './Event'
 
 class App extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      web3: null,
-      tickets: []
-    }
-  }
-
-  componentWillMount() {
-    getWeb3
-    .then(results => {
-      this.setState({ web3: results.web3 })
-      this.instantiateContract()
-    })
-    .catch(() => {
-      console.log('Error finding web3.')
-    })
-  }
-
-  instantiateContract() {
-    const contract = require('truffle-contract')
-    const eventContract = contract(EventContract)
-    eventContract.setProvider(this.state.web3.currentProvider)
-
-    eventContract.deployed().then((instance) => {
-      instance.getTickets.call().then((data) => {
-        let tickets = []
-        let numTickets = data[0].length
-        for (let i = 0; i < numTickets; i++) {
-          tickets.push({
-            identifier: data[0][i].toNumber(),
-            price: data[1][i].toNumber()
-          })
-        }
-        return this.setState({tickets: tickets})
-      })
-    })
-  }
-
-  render() {
+  render () {
     return (
-      <div>
-        <ul>
-          {this.state.tickets.map(this.renderTicket)}
-        </ul>
-      </div>
-    );
-  }
-
-  renderTicket(ticket) {
-    return (
-      <li key={ticket.identifier}>
-        {ticket.identifier} {ticket.price}
-      </li>
+      <BrowserRouter>
+        <div>
+          <Route exact path="/" component={NewEvent}/>
+          <Route path="/:contractAddress" component={Event}/>
+        </div>
+      </BrowserRouter>
     )
   }
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-});

--- a/client/src/Event.js
+++ b/client/src/Event.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import EventContract from './contracts/Event.json'
+import getWeb3 from './utils/getWeb3'
+
+class Event extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      web3: null,
+      tickets: []
+    }
+  }
+
+  componentWillMount() {
+    getWeb3
+    .then(results => {
+      this.setState({ web3: results.web3 })
+      this.instantiateContract()
+    })
+    .catch(() => {
+      console.log('Error finding web3.')
+    })
+  }
+
+  instantiateContract() {
+    const contract = require('truffle-contract')
+    const eventContract = contract(EventContract)
+    const contractAddress = this.props.match.params.contractAddress
+
+    eventContract.setProvider(this.state.web3.currentProvider)
+
+    eventContract.at(contractAddress).then((instance) => {
+      instance.getTickets.call().then((data) => {
+        let tickets = []
+        let numTickets = data[0].length
+        for (let i = 0; i < numTickets; i++) {
+          tickets.push({
+            identifier: data[0][i].toNumber(),
+            price: data[1][i].toNumber()
+          })
+        }
+        return this.setState({tickets: tickets})
+      })
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        <ul>
+          {this.state.tickets.map(this.renderTicket)}
+        </ul>
+      </div>
+    );
+  }
+
+  renderTicket(ticket) {
+    return (
+      <li key={ticket.identifier}>
+        {ticket.identifier} {ticket.price}
+      </li>
+    )
+  }
+}
+
+Event.propTypes = {
+  contractAddress: PropTypes.string
+};
+
+export default Event;

--- a/client/src/NewEvent.js
+++ b/client/src/NewEvent.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+class NewEvent extends Component {
+  render () {
+    return (
+      <div>
+        New Event
+      </div>
+    )
+  }
+}
+
+export default NewEvent

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2983,6 +2983,16 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2998,6 +3008,10 @@ hoek@2.x.x:
 hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+
+hoist-non-react-statics@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3237,7 +3251,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@^2.2.2:
+invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4045,7 +4059,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4642,7 +4656,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
+path-to-regexp@^1.0.1, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -5064,7 +5078,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5219,6 +5233,29 @@ react-error-overlay@^2.0.2:
     react-dom "^15 || ^16"
     settle-promise "1.0.0"
     source-map "0.5.6"
+
+react-router-dom@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+  dependencies:
+    history "^4.7.2"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.4"
+    react-router "^4.2.0"
+    warning "^3.0.0"
+
+react-router@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.3.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
 
 react-scripts@1.0.14:
   version "1.0.14"
@@ -5553,6 +5590,10 @@ resolve-dir@^1.0.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -6392,6 +6433,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -6419,6 +6464,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"


### PR DESCRIPTION
and new components for creating a new event and viewing an exiting event

Events are now accessed by 
visiting `localhost:3000/0xd29457890880ce8d80928911ce9a01d6479b8496`

where the address is found by looking at your recent migration to test rpc:

```
eth_sendTransaction

  Transaction: 0x99810084b82fc53496fcf6be9c7e70caf6fbe109bd35bb162e04e014f457f104
  Contract created: 0xd29457890880ce8d80928911ce9a01d6479b8496
  Gas usage: 1456033
  Block Number: 3
  Block Time: Sat Oct 14 2017 13:12:23 GMT-0400 (EDT)
```

In a follow up we will redirect to this page after the Event is created